### PR TITLE
Make the Alakarte logo a link to the website.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ export default loader({ print: ['data'], delay: 200 })(MyComponent)
 
 By default, no delay is defined.
 
-# About [![alakarteio](http://alakarte.io/assets/img/logo.markdown.png)](http://alakarte.io)
+# About [![alakarteio](https://alakarte.io/assets/img/logo.markdown.png)](https://alakarte.io)
 **alakarteio** is created by two passionate french developers.
 
 Do you want to contact them ? Go to their [website](http://alakarte.io)

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ export default loader({ print: ['data'], delay: 200 })(MyComponent)
 
 By default, no delay is defined.
 
-# About ![alakarteio](http://alakarte.io/assets/img/logo.markdown.png)
+# About [![alakarteio](http://alakarte.io/assets/img/logo.markdown.png)](http://alakarte.io)
 **alakarteio** is created by two passionate french developers.
 
 Do you want to contact them ? Go to their [website](http://alakarte.io)


### PR DESCRIPTION
The Alakarte logo was clickable but gave a link to the image.
With this PR, clicking on the image now lead to the alakarte.io website.